### PR TITLE
feat[PAT-64]: Delete consultation

### DIFF
--- a/com/frontend/app/src/components/TicketMenu.jsx
+++ b/com/frontend/app/src/components/TicketMenu.jsx
@@ -1,0 +1,48 @@
+import React, { useState } from 'react';
+import Menu from '@mui/material/Menu';
+import IconButton from '@mui/material/IconButton';
+import MoreHorizIcon from '@mui/icons-material/MoreHoriz';
+
+/**
+ * TicketMenu is a component that displays a menu icon, and when clicked, it opens a menu anchored to the top right corner.
+ *
+ * @param {boolean} showMenu - A boolean indicating whether the menu should be visible or hidden.
+ * @param {ReactNode} children - The content to be displayed inside the menu.
+ * @returns {JSX.Element} - The JSX element representing the TicketMenu.
+ */
+const TicketMenu = ({showMenu, children}) => {
+    const [anchorEl, setAnchorEl] = useState(null);
+
+    const handleMenuClick = (event) => {
+        setAnchorEl(event.currentTarget);
+    };
+
+    const handleMenuClose = () => {
+        setAnchorEl(null);
+    };
+
+
+    return (
+        <div
+            style={{
+            position: 'absolute',
+            top: 0,
+            right: 0,
+            visibility: showMenu ? 'visible' : 'hidden',
+            }}
+        >
+            <IconButton aria-label="menu-ticket" onClick={handleMenuClick}>
+            <MoreHorizIcon/>
+            </IconButton>
+            <Menu
+            anchorEl={anchorEl}
+            open={Boolean(anchorEl)}
+            onClose={handleMenuClose}
+            >
+            {children}
+            </Menu>
+        </div>
+    )
+};
+
+export default TicketMenu;

--- a/com/frontend/app/src/containers/Consultancy.jsx
+++ b/com/frontend/app/src/containers/Consultancy.jsx
@@ -8,7 +8,6 @@
 
 import React, { useEffect, useState } from 'react';
 import { DragDropContext, Droppable } from 'react-beautiful-dnd';
-import CardPanel from './CardPanel';
 import styled from '@emotion/styled';
 import { Stack } from '@mui/material';
 import {

--- a/com/frontend/app/src/containers/ConsultationPanel.jsx
+++ b/com/frontend/app/src/containers/ConsultationPanel.jsx
@@ -4,7 +4,7 @@
 * We are also passing the droppableId and index properties to Droppable.           *
 * Also, we are using the CustomCard component to render each card within the panel.*
 ***********************************************************************************/
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Droppable } from 'react-beautiful-dnd';
 import Grid from '@mui/material/Grid';
 import { Paper } from '@mui/material';
@@ -20,6 +20,12 @@ import ConsultationTicket from './ConsultationTicket';
  * @returns {JSX.Element} - A React element representing the ConsultationPanel.
  */
 const ConsultationPanel = ({ panel, index }) => {
+  const [titleUpdateCount, setTitleUpdateCount] = useState(0); // force update view
+  const [panelData, setPanelData] = useState(panel);
+
+  useEffect(() => {
+    setPanelData(panel);
+  }, [panel]);
 
   const panelStyle = {
     backgroundColor: panel.id === 0 ? '#87cefaab' : 'lightskyblue',
@@ -32,15 +38,24 @@ const ConsultationPanel = ({ panel, index }) => {
     return <div>No panels.</div>;
   }
 
+  /**
+   * Reduces the number of cards in the panel and updates the state.
+   */
+  const reduce_number_cards = () => {
+    panelData.number_cards = panelData.number_cards - 1;
+    setPanelData(panelData);
+    setTitleUpdateCount(titleUpdateCount + 1);
+  };
+
   return (
-    <Droppable key={"droppeable-panel-"+String(panel.id)} droppableId={String(panel.id)} index={index} direction="vertical">
+    <Droppable key={"droppeable-panel-"+String(panelData.id)} droppableId={String(panelData.id)} index={index} direction="vertical">
       {(provided) => (
         <Paper ref={provided.innerRef} {...provided.droppableProps}  style={panelStyle}>
-            <TitlePanel panel={panel}/>
+            <TitlePanel panel={panelData}/>
             <Grid container  columns={12} spacing={2}  style={{width: '20vw', backgroundColor: '#d7f0fa' , flexDirection: 'column', margin: '0 auto'}} >
-                {panel.cards.map((card, index) => (
+                {panelData.cards.map((card, index) => (
                     <Grid item xs={12} sm={6} md={11} key={card.consultation} >
-                    <ConsultationTicket card={card} index={index} key={card.consultation}/>
+                    <ConsultationTicket card={card} index={index} reduce_number_cards={reduce_number_cards} key={card.consultation}/>
                     </Grid>
                 ))}
                 {provided.placeholder}

--- a/com/frontend/app/src/containers/ConsultationPanel.jsx
+++ b/com/frontend/app/src/containers/ConsultationPanel.jsx
@@ -42,7 +42,7 @@ const ConsultationPanel = ({ panel, index }) => {
    * Reduces the number of cards in the panel and updates the state.
    */
   const reduce_number_cards = () => {
-    panelData.number_cards = panelData.number_cards - 1;
+    panelData.number_cards --;
     setPanelData(panelData);
     setTitleUpdateCount(titleUpdateCount + 1);
   };

--- a/com/frontend/app/src/containers/ConsultationTicket.jsx
+++ b/com/frontend/app/src/containers/ConsultationTicket.jsx
@@ -3,7 +3,7 @@
  * component to make the card draggable. We are also passing              *
  * the properties "draggableId " and "index" to a "Draggable".            *
  **************************************************************************/
-import React from 'react';
+import React, { useEffect } from 'react';
 import {useState} from 'react';
 import { Draggable } from 'react-beautiful-dnd';
 import Card from '@mui/material/Card';
@@ -14,6 +14,7 @@ import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import IconButton from '@mui/material/IconButton';
 import MoreHorizIcon from '@mui/icons-material/MoreHoriz';
+import { deleteConsultation } from '../utils/caseTaker.jsx';
 
 
 /**
@@ -32,9 +33,18 @@ const ConsultationTicket = ({card,index}) => {
   const [tag, setTag] = useState(card.tag);
   const [anchorEl, setAnchorEl] = useState(null);
   const [showMenu,setShowMenu] = useState(false)
+  const [isDeleted, setIsDeleted] = useState(false);
+
+
+  useEffect(() => {
+  }, [isDeleted]);
 
   if (card == null || card.length === 0) {
     return <div>No cards.</div>;
+  }
+
+  if (isDeleted) {
+    return null;
   }
 
   const showConsultationHandler = () => {
@@ -49,10 +59,13 @@ const ConsultationTicket = ({card,index}) => {
     setAnchorEl(event.currentTarget);
   };
 
-  const handleDeleteClick = () => {
-    //TODO: Llama a la función deleteConsultation aquí
-    console.log('Deleting');
+  const handleDeleteClick = async() => {
+    const deleted = await deleteConsultation(card.consultation);
     setAnchorEl(null);
+    if (deleted) {
+      setIsDeleted(true);
+      console.log(deleted)
+    }
   };
 
   const handleMenuClose = () => {

--- a/com/frontend/app/src/containers/ConsultationTicket.jsx
+++ b/com/frontend/app/src/containers/ConsultationTicket.jsx
@@ -26,9 +26,10 @@ import { deleteConsultation } from '../utils/caseTaker.jsx';
  *
  * @param {Object} card - The card object containing information to display.
  * @param {number} index - The index of the card in the list.
+ * @param {function} callback - Update Panel View with the new number of cards.
  * @returns {JSX.Element} - The JSX element representing the custom card.
  */
-const ConsultationTicket = ({card,index}) => {
+const ConsultationTicket = ({card, index, reduce_number_cards}) => {
   const [openDialog, setOpenDialog] = useState(false);
   const [tag, setTag] = useState(card.tag);
   const [anchorEl, setAnchorEl] = useState(null);
@@ -64,7 +65,7 @@ const ConsultationTicket = ({card,index}) => {
     setAnchorEl(null);
     if (deleted) {
       setIsDeleted(true);
-      console.log(deleted)
+      reduce_number_cards();
     }
   };
 

--- a/com/frontend/app/src/containers/ConsultationTicket.jsx
+++ b/com/frontend/app/src/containers/ConsultationTicket.jsx
@@ -10,6 +10,10 @@ import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import Typography from '@mui/material/Typography';
 import ConsutationDisplay from '../components/ConsutationDisplay.jsx'
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
+import IconButton from '@mui/material/IconButton';
+import MoreHorizIcon from '@mui/icons-material/MoreHoriz';
 
 
 /**
@@ -26,6 +30,8 @@ import ConsutationDisplay from '../components/ConsutationDisplay.jsx'
 const ConsultationTicket = ({card,index}) => {
   const [openDialog, setOpenDialog] = useState(false);
   const [tag, setTag] = useState(card.tag);
+  const [anchorEl, setAnchorEl] = useState(null);
+  const [showMenu,setShowMenu] = useState(false)
 
   if (card == null || card.length === 0) {
     return <div>No cards.</div>;
@@ -39,6 +45,20 @@ const ConsultationTicket = ({card,index}) => {
     setOpenDialog(false)
   }
 
+  const handleMenuClick = (event) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleDeleteClick = () => {
+    //TODO: Llama a la función deleteConsultation aquí
+    console.log('Deleting');
+    setAnchorEl(null);
+  };
+
+  const handleMenuClose = () => {
+    setAnchorEl(null);
+  };
+
   return (
     <Draggable draggableId={String(card.consultation)} index={index}>
       {(provided) => (
@@ -47,8 +67,30 @@ const ConsultationTicket = ({card,index}) => {
           {...provided.draggableProps}
           {...provided.dragHandleProps}
         >
-          <Card style={{width: '15vw', margin: '0 auto' }} onDoubleClick={showConsultationHandler}>
-            <CardContent>
+          <Card style={{width: '15vw', margin: '0 auto' , position: 'relative'}} onDoubleClick={showConsultationHandler}>
+            <CardContent
+              onMouseEnter={() => setShowMenu(true)}
+              onMouseLeave={() => setShowMenu(false)}
+            >
+              <div
+                style={{
+                  position: 'absolute',
+                  top: 0,
+                  right: 0,
+                  visibility: showMenu ? 'visible' : 'hidden',
+                }}
+              >
+                <IconButton aria-label="menu-ticket" onClick={handleMenuClick}>
+                  <MoreHorizIcon/>
+                </IconButton>
+                <Menu
+                  anchorEl={anchorEl}
+                  open={Boolean(anchorEl)}
+                  onClose={handleMenuClose}
+                >
+                  <MenuItem onClick={handleDeleteClick}>Delete Consultation</MenuItem>
+                </Menu>
+              </div>
               <Typography
                 color="textSecondary"
                 gutterBottom

--- a/com/frontend/app/src/containers/ConsultationTicket.jsx
+++ b/com/frontend/app/src/containers/ConsultationTicket.jsx
@@ -10,11 +10,9 @@ import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import Typography from '@mui/material/Typography';
 import ConsutationDisplay from '../components/ConsutationDisplay.jsx'
-import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
-import IconButton from '@mui/material/IconButton';
-import MoreHorizIcon from '@mui/icons-material/MoreHoriz';
 import { deleteConsultation } from '../utils/caseTaker.jsx';
+import TicketMenu from '../components/TicketMenu.jsx';
 
 
 /**
@@ -32,7 +30,6 @@ import { deleteConsultation } from '../utils/caseTaker.jsx';
 const ConsultationTicket = ({card, index, reduce_number_cards}) => {
   const [openDialog, setOpenDialog] = useState(false);
   const [tag, setTag] = useState(card.tag);
-  const [anchorEl, setAnchorEl] = useState(null);
   const [showMenu,setShowMenu] = useState(false)
   const [isDeleted, setIsDeleted] = useState(false);
 
@@ -56,21 +53,12 @@ const ConsultationTicket = ({card, index, reduce_number_cards}) => {
     setOpenDialog(false)
   }
 
-  const handleMenuClick = (event) => {
-    setAnchorEl(event.currentTarget);
-  };
-
   const handleDeleteClick = async() => {
     const deleted = await deleteConsultation(card.consultation);
-    setAnchorEl(null);
     if (deleted) {
       setIsDeleted(true);
       reduce_number_cards();
     }
-  };
-
-  const handleMenuClose = () => {
-    setAnchorEl(null);
   };
 
   return (
@@ -86,29 +74,10 @@ const ConsultationTicket = ({card, index, reduce_number_cards}) => {
               onMouseEnter={() => setShowMenu(true)}
               onMouseLeave={() => setShowMenu(false)}
             >
-              <div
-                style={{
-                  position: 'absolute',
-                  top: 0,
-                  right: 0,
-                  visibility: showMenu ? 'visible' : 'hidden',
-                }}
-              >
-                <IconButton aria-label="menu-ticket" onClick={handleMenuClick}>
-                  <MoreHorizIcon/>
-                </IconButton>
-                <Menu
-                  anchorEl={anchorEl}
-                  open={Boolean(anchorEl)}
-                  onClose={handleMenuClose}
-                >
-                  <MenuItem onClick={handleDeleteClick}>Delete Consultation</MenuItem>
-                </Menu>
-              </div>
-              <Typography
-                color="textSecondary"
-                gutterBottom
-              >
+              <TicketMenu showMenu={showMenu}>
+                <MenuItem onClick={handleDeleteClick}>Delete Consultation</MenuItem>
+              </TicketMenu>
+              <Typography color="textSecondary" gutterBottom>
                 {tag}
               </Typography>
             </CardContent>

--- a/com/frontend/app/src/utils/caseTaker.jsx
+++ b/com/frontend/app/src/utils/caseTaker.jsx
@@ -127,6 +127,40 @@ export const updateConsultationField = async (id, fieldName, fieldValue) => {
 };
 
 
+/**
+ * Delete a Consultation.
+ * @param {int} consultationID - consultation id.
+ * @returns {Promise<boolean>} True if successfully deleted the Consultation. Otherwise false.
+ */
+export async function deleteConsultation(consultationID) {
+    try {
+        const url = process.env.REACT_APP_URL_BASE_API_REST_PATROCINIO
+        + process.env.REACT_APP_PATH_CONSULTATIONS
+        + String(consultationID)
+        + "/"
+
+        const response = await fetch(url, {
+            method: 'DELETE',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+        })
+
+        if (!response.ok) {
+            console.error('Failed to DELETE Consultation', consultationID ,'. Status code:', response.status);
+            return false;
+            }
+
+        console.log("Successful delete Consultation ID:", consultationID)
+        return true;
+    } catch (error) {
+        console.error('Error in delete consultation.');
+        console.debug(error)
+        throw error;
+    }
+}
+
+
 /********************** CONSULTATION REQUEST *************************/
 
 /**


### PR DESCRIPTION
- Se crea un com,ponente TicketMenu en forma de [...] 3 puntos que despliega un menu operable.
- Se agrega a los ConsultationTickets un menu desplegable  (visible unicamente en MouseOver) con la opción Delete Consultation.
- Al seleccionar la opcion Delete consultation, se comunica con la API del backend, elimina la consulta y actualiza la vista con la cantidad de tickets en el panel.