### PR TITLE
feat:[PAT-62]: Edit board name

### DIFF
--- a/com/frontend/app/src/components/TitleEditable.jsx
+++ b/com/frontend/app/src/components/TitleEditable.jsx
@@ -1,0 +1,61 @@
+import { Box, TextField } from "@mui/material";
+import { useState } from "react";
+import Title from "./Title";
+
+
+const titleStyle = {
+    style: {
+      fontSize: '1.5rem', // Adjust the font size as needed
+      color: 'white',    // Text color
+    },
+}
+
+
+/**
+ * TitleEditable is a React component that allows for editing a title in a user-friendly manner.
+ * It provides an input field for editing when double-clicked and displays the title when not in edit mode.
+ *
+ * @param {string} title - The current title to display and edit.
+ * @param {function} saveTitle - A callback function to handle when the title input field loses focus.
+ *
+ * @returns {JSX.Element} - A JSX element representing the editable title component.
+ */
+const TitleEditable = ({title, saveTitle}) => {
+    const [isEditing, setIsEditing] = useState(false);
+    const [editedTitle, setEditedTitle] = useState(title);
+
+    const handleDoubleClick = () => {
+        setEditedTitle(title);
+        setIsEditing(true);
+    };
+
+    const handleTitleChange = (event) => {
+        setEditedTitle(event.target.value);
+    };
+
+    const handleTitleBlur = async (event) => {
+        const newTitle = event.target.value;
+        saveTitle(newTitle);
+        setIsEditing(false);
+    };
+
+    return (
+        <Box>
+            {isEditing ? (
+            <TextField
+                value={editedTitle}
+                onChange={handleTitleChange}
+                onBlur={handleTitleBlur}
+                autoFocus
+                fullWidth
+                variant="outlined"
+                InputProps={titleStyle}
+                />
+            ) : (
+                <Title onDoubleClick={handleDoubleClick}>{title}</Title>
+            )}
+        </Box>
+    );
+};
+
+export default TitleEditable;

--- a/com/frontend/app/src/components/TitlePanel.jsx
+++ b/com/frontend/app/src/components/TitlePanel.jsx
@@ -1,16 +1,8 @@
 import React, { useState } from 'react';
 import Title from '../components/Title';
 import { Badge, Tooltip, Box } from '@mui/material';
-import TextField from '@mui/material/TextField';
 import { updatPanelTitle } from '../utils/panel';
-
-const titleStyle = {
-    style: {
-      fontSize: '1.5rem', // Adjust the font size as needed
-      color: 'white',    // Text color
-    },
-}
-
+import TitleEditable from './TitleEditable';
 
 /**
  * TitlePanel component displays the title of a panel and a badge with the number of cards it contains.
@@ -20,44 +12,22 @@ const titleStyle = {
  * @returns {JSX.Element} - A React element representing the TitlePanel.
  */
 const TitlePanel = ({panel, isEditable=false}) => {
-    const [isEditing, setIsEditing] = useState(false);
-    const [editedTitle, setEditedTitle] = useState(panel.title);
     const [title, setTitle] = useState(panel.title);
 
-    const handleDoubleClick = () => {
-        if (isEditable) {
-            setEditedTitle(title);
-            setIsEditing(true);
-        }
-    };
 
-    const handleTitleChange = (event) => {
-        setEditedTitle(event.target.value);
-    };
-
-    const handleTitleBlur = async () => {
-        const newTitle = await updatPanelTitle(panel.id, editedTitle);
-        if (newTitle !== null && newTitle !== undefined) {
-            setTitle(newTitle);
+    const saveTitle = async (newTitle) => {
+        const titleResponse = await updatPanelTitle(panel.id, newTitle);
+        if (titleResponse !== null && titleResponse !== undefined) {
+            setTitle(titleResponse);
         }
-        setIsEditing(false);
     };
 
     return (
         <Box style={{ position: 'relative' }}>
-            {isEditing ? (
-            <TextField
-                value={editedTitle}
-                onChange={handleTitleChange}
-                onBlur={handleTitleBlur}
-                autoFocus
-                fullWidth
-                variant="outlined"
-                InputProps={titleStyle}
-                />
-            ) : (
-                <Title onDoubleClick={handleDoubleClick}>{title}</Title>
-            )}
+            {isEditable? 
+                (<TitleEditable title={title} saveTitle={saveTitle}/>):
+                ( <Title> {title}</Title>)
+            }
             <Tooltip title={`Contains ${panel.number_cards} tickets`}>
             {/*Badge with number of cards in the panel*/}
             <Badge

--- a/com/frontend/app/src/pages/BoardPage.jsx
+++ b/com/frontend/app/src/pages/BoardPage.jsx
@@ -4,21 +4,20 @@ import Dashboard from '../containers/Dashboard';
 import Board from '../containers/Board';
 import { useParams } from 'react-router-dom';
 import getDataBoard, { updatBoardTitle } from '../utils/board';
-import Title from '../components/Title';
-import { TextField } from '@mui/material';
+import TitleEditable from '../components/TitleEditable';
 
-const titleStyle = {
-    style: {
-      fontSize: '1.5rem', // Adjust the font size as needed
-      color: 'white',    // Text color
-    },
-}
+
 const theme = createTheme();
+
+
+/**
+ * BoardPage is a React component representing a page displaying the content of a specific board.
+ *
+ * @returns {JSX.Element} - A JSX element representing the board page.
+ */
 export default function BoardPage( ) {
     const { id_board } = useParams();
     const [title, setTitle] = React.useState('Undefine Title');
-    const [isEditing, setIsEditing] = React.useState(false);
-    const [editedTitle, setEditedTitle] = React.useState(title);
 
     useEffect(() => {
         const fetchBoardTitle = async () => {
@@ -33,40 +32,18 @@ export default function BoardPage( ) {
         };
         fetchBoardTitle();
     }, [id_board]);
-
-
-    const handleDoubleClick = () => {
-            setEditedTitle(title);
-            setIsEditing(true);
-    };
-
-    const handleTitleChange = (event) => {
-        setEditedTitle(event.target.value);
-    };
-
-    const handleTitleBlur = async () => {
-        const newTitle = await updatBoardTitle(id_board, editedTitle);
-        if (newTitle !== null && newTitle !== undefined) {
-            setTitle(newTitle);
+    
+    const saveTitle = async (newTitle) => {
+        const responseTitle = await updatBoardTitle(id_board, newTitle);
+        if (responseTitle !== null && responseTitle !== undefined) {
+            setTitle(responseTitle);
         }
-        setIsEditing(false);
     };
+    const titleComponent = TitleEditable({title, saveTitle});
 
     return (
         <ThemeProvider theme={theme}>
-            <Dashboard title={isEditing ? (
-            <TextField
-                value={editedTitle}
-                onChange={handleTitleChange}
-                onBlur={handleTitleBlur}
-                autoFocus
-                fullWidth
-                variant="outlined"
-                InputProps={titleStyle}
-                />
-            ) : (
-                <Title onDoubleClick={handleDoubleClick}>{title}</Title>
-            )}>
+            <Dashboard title={titleComponent}>
                 <Board  id={String(id_board)} />
             </Dashboard>
         </ThemeProvider>

--- a/com/frontend/app/src/pages/BoardPage.jsx
+++ b/com/frontend/app/src/pages/BoardPage.jsx
@@ -3,12 +3,22 @@ import { createTheme, ThemeProvider } from '@mui/material/styles';
 import Dashboard from '../containers/Dashboard';
 import Board from '../containers/Board';
 import { useParams } from 'react-router-dom';
-import getDataBoard from '../utils/board';
+import getDataBoard, { updatBoardTitle } from '../utils/board';
+import Title from '../components/Title';
+import { TextField } from '@mui/material';
 
+const titleStyle = {
+    style: {
+      fontSize: '1.5rem', // Adjust the font size as needed
+      color: 'white',    // Text color
+    },
+}
 const theme = createTheme();
 export default function BoardPage( ) {
     const { id_board } = useParams();
     const [title, setTitle] = React.useState('Undefine Title');
+    const [isEditing, setIsEditing] = React.useState(false);
+    const [editedTitle, setEditedTitle] = React.useState(title);
 
     useEffect(() => {
         const fetchBoardTitle = async () => {
@@ -24,9 +34,39 @@ export default function BoardPage( ) {
         fetchBoardTitle();
     }, [id_board]);
 
+
+    const handleDoubleClick = () => {
+            setEditedTitle(title);
+            setIsEditing(true);
+    };
+
+    const handleTitleChange = (event) => {
+        setEditedTitle(event.target.value);
+    };
+
+    const handleTitleBlur = async () => {
+        const newTitle = await updatBoardTitle(id_board, editedTitle);
+        if (newTitle !== null && newTitle !== undefined) {
+            setTitle(newTitle);
+        }
+        setIsEditing(false);
+    };
+
     return (
         <ThemeProvider theme={theme}>
-            <Dashboard title={title}>
+            <Dashboard title={isEditing ? (
+            <TextField
+                value={editedTitle}
+                onChange={handleTitleChange}
+                onBlur={handleTitleBlur}
+                autoFocus
+                fullWidth
+                variant="outlined"
+                InputProps={titleStyle}
+                />
+            ) : (
+                <Title onDoubleClick={handleDoubleClick}>{title}</Title>
+            )}>
                 <Board  id={String(id_board)} />
             </Dashboard>
         </ThemeProvider>

--- a/com/frontend/app/src/utils/board.jsx
+++ b/com/frontend/app/src/utils/board.jsx
@@ -92,3 +92,44 @@ export const getListBoard = async () => {
       throw error;
   }
 }
+
+
+/**
+ * Updates the title of a Board by sending a PATCH request to the API.
+ *
+ * @param {number} id - The ID of the Board to update.
+ * @param {string} newTitle - The new title to set for the Board.
+ * @returns {Promise<string|null>} - A promise that resolves to the updated title if successful, or null if there was an error.
+ */
+export const updatBoardTitle = async (id, newTitle) => {
+  try {
+      const url = process.env.REACT_APP_URL_BASE_API_REST_PATROCINIO
+                  + process.env.REACT_APP_PATH_BOARD
+                  + String(id)
+                  + "/";
+
+      const response = await fetch(url, {
+          method: 'PATCH',
+          headers: {
+              'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+              "title": newTitle
+          }),
+      })
+
+      if (response.ok) {
+          const requestPanel = await response.json();
+
+          return requestPanel['title'];
+
+      } else {
+          console.warn(`Failed to update the Title field of Board.`);
+          return null;
+      }
+  } catch (error) {
+      console.error(`Error while making the PATCH request for the Title field of Board:`, error.message);
+      console.debug(error);
+      throw error;
+  }
+};


### PR DESCRIPTION
- Se permite la actualización del titlu de Board desde la pagina web con un doble click.
- Se agrega funcion para interarctuar con el backend y actualizar el titulo del Board.
- Se crea con el fin de modularizar, un componente llamado TitleEditable.