### PR TITLE
feat[PAT-63]: Delete panel from BoardPage

### DIFF
--- a/com/backend/app/Clients/test/test_clients.py
+++ b/com/backend/app/Clients/test/test_clients.py
@@ -1,11 +1,10 @@
 from rest_framework.test import APITestCase, APIRequestFactory
-from django.urls import reverse, resolve
+from django.urls import reverse
 from rest_framework import status
 from django.contrib.auth.models import User
 from Clients.api.viewsets import *
 from rest_framework.test import force_authenticate
 from django.urls import reverse 
-from django.test.client import  RequestFactory
 from rest_framework.test import APIClient
 from locality.test.utils import *
 from Clients.choices import *
@@ -46,7 +45,3 @@ class Test_clients(APITestCase):
         view = ClientViewSet.as_view({'post':'create'})
         response = view(request)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-       
-
-
-    

--- a/com/backend/app/Panel/api/viewsets.py
+++ b/com/backend/app/Panel/api/viewsets.py
@@ -1,3 +1,4 @@
+import logging
 from rest_framework.viewsets import ModelViewSet
 from Panel.models import Panel
 from Panel.api.serializers import (
@@ -7,12 +8,30 @@ from Panel.api.serializers import (
 )
 from rest_framework.response import Response
 from django.db.models import Prefetch, Count
+from rest_framework import status
+from rest_framework.decorators import action
+
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
 
 class PanelViewSet(ModelViewSet):
     queryset = Panel.objects.all()
     serializer_class = PanelSerializer
 
     def retrieve(self, request, *args, **kwargs):
+        """
+        Retrieve a specific panel and its associated cards.
+
+        Args:
+            request: The HTTP request object.
+            args: Additional positional arguments.
+            kwargs: Additional keyword arguments.
+
+        Returns:
+            An HTTP response that includes the panel and its associated cards.
+        """
         self.serializer_class = PanelFullSerializer
         self.queryset = self.queryset.prefetch_related(
                         Prefetch('cards')
@@ -20,6 +39,17 @@ class PanelViewSet(ModelViewSet):
         return super().retrieve(request, *args, **kwargs)
 
     def list(self, request, *args, **kwargs):
+        """
+        List all panels with the number of associated cards.
+
+        Args:
+            request: The HTTP request object.
+            args: Additional positional arguments.
+            kwargs: Additional keyword arguments.
+
+        Returns:
+            An HTTP response that includes the list of panels with the number of associated cards.
+        """
         self.queryset = Panel.objects.prefetch_related(
             Prefetch('cards')
         ).annotate(
@@ -27,3 +57,71 @@ class PanelViewSet(ModelViewSet):
         )
         self.serializer_class = PanelWithNumberCardsSerializer
         return super().list(request, *args, **kwargs)
+
+    def destroy(self, request, *args, **kwargs):
+        """
+        Delete a panel if it has no associated cards; otherwise, return an error.
+
+        Args:
+            request: The HTTP request object.
+            args: Additional positional arguments.
+            kwargs: Additional keyword arguments.
+
+        Returns:
+            An HTTP response indicating whether the panel was deleted or if there was a conflict due to associated cards.
+        """
+        queryset = Panel.objects.prefetch_related(
+            Prefetch('cards')
+        ).annotate(
+            number_cards=Count('cards', distinct=True)
+        )
+        serializer = PanelWithNumberCardsSerializer
+        response = serializer(queryset, many=True)
+
+        if response.data == [] :
+            logger.error('Panel not found')
+            return Response(
+                data={"message": "Panel not found"},
+                status=status.HTTP_404_NOT_FOUND
+            )
+
+        panel = response.data[0]
+        if panel["number_cards"] == 0:
+            logger.info('No cards associated with panel, deleting panel..')
+            response = super().destroy(request, *args, **kwargs)
+
+            if response.status_code < 400 :
+                message = "Panel deleted successfully"
+                status_code = 200
+                logger.info(message)
+            else:
+                logger.error('Unexpected error, status code: %d', response.status_code)
+                status_code = response.status_code
+
+            response = Response(
+                data={"message": message},
+                status=status_code
+            )
+            return response
+
+        else:
+            logger.error('Panel has cards assigned and cannot be deleted')
+            return Response(
+                data={"message": "Panel has cards assigned and cannot be deleted"},
+                status=status.HTTP_409_CONFLICT
+            )
+
+    @action(detail=True, methods=['delete'], url_name='force-destroy', url_path='force-destroy')
+    def force_destroy(self, request, *args, **kwargs):
+        """
+        Forcefully delete a panel, even if it has cards assigned.
+
+        Args:
+            request: The HTTP request object.
+            args: Additional positional arguments.
+            kwargs: Additional keyword arguments.
+
+        Returns:
+            An HTTP response indicating whether the panel was deleted.
+        """
+        return super().destroy(request, *args, **kwargs)

--- a/com/frontend/app/src/containers/CardPanel.jsx
+++ b/com/frontend/app/src/containers/CardPanel.jsx
@@ -6,6 +6,10 @@ import BasePanel from '../components/BasePanel';
 import TicketMenu from '../components/TicketMenu';
 import { MenuItem } from '@mui/material';
 import { deletePanel } from '../utils/panel';
+import Alert from '@mui/material/Alert';
+import AlertTitle from '@mui/material/AlertTitle';
+import Snackbar from '@mui/material/Snackbar';
+
 
 
 /**
@@ -19,9 +23,25 @@ const CardPanel = ({ panel, index }) => {
   const [showMenu, setShowMenu] = useState(false);
   const title = TitlePanel({panel:panel, isEditable: true});
   const [isDeleted, setIsDeleted] = useState(false);
+  const [deleteError, setDeleteError] = useState(null);
+
 
   useEffect(() => {
   }, [isDeleted]);
+
+    useEffect(() => {
+      // Borra el mensaje de error después de 5 segundos
+      if (deleteError) {
+        const timer = setTimeout(() => {
+          setDeleteError(null);
+        }, 5000); // 5000 milisegundos = 5 segundos
+  
+        return () => {
+          clearTimeout(timer); // Limpia el temporizador si el componente se desmonta antes
+        };
+      }
+    }, [deleteError]);
+
 
   if(isDeleted) {
     return null;
@@ -36,8 +56,14 @@ const CardPanel = ({ panel, index }) => {
       deletePanel(panel.id).then((deleted) => {
         if(deleted){
           setIsDeleted(true);
+        } else {
+          setDeleteError("No se pudo eliminar el panel por algún motivo...");
         }
+      }).catch((error) => {
+        setDeleteError("No se pudo eliminar el panel debido a un error en la solicitud.");
       });
+    } else {
+      setDeleteError("No se pudo eliminar el panel por algún motivo...");
     }
   };
 
@@ -58,6 +84,17 @@ const CardPanel = ({ panel, index }) => {
 
 
   return (
+    <div>
+          <Snackbar open={!!deleteError} autoHideDuration={5000} onClose={() => setDeleteError(null)}>
+
+
+        {/* {deleteError && ( */}
+        <Alert severity="error" key={"delete-error"}>
+          <AlertTitle>Error</AlertTitle>
+          {deleteError}
+        </Alert>
+      {/* )} */}
+          </Snackbar>
     <div
       onMouseEnter={()=> setShowMenu(true)}
       onMouseLeave={()=> setShowMenu(false)}
@@ -72,6 +109,7 @@ const CardPanel = ({ panel, index }) => {
                     ))}
         </BasePanel>
         {menuComponent}
+    </div>
     </div>
   );
 };

--- a/com/frontend/app/src/containers/CardPanel.jsx
+++ b/com/frontend/app/src/containers/CardPanel.jsx
@@ -23,25 +23,11 @@ const CardPanel = ({ panel, index }) => {
   const [showMenu, setShowMenu] = useState(false);
   const title = TitlePanel({panel:panel, isEditable: true});
   const [isDeleted, setIsDeleted] = useState(false);
-  const [deleteError, setDeleteError] = useState(null);
+  const [alertMessage, setAlertMessage] = useState(null);
 
 
   useEffect(() => {
   }, [isDeleted]);
-
-    useEffect(() => {
-      // Borra el mensaje de error después de 5 segundos
-      if (deleteError) {
-        const timer = setTimeout(() => {
-          setDeleteError(null);
-        }, 5000); // 5000 milisegundos = 5 segundos
-  
-        return () => {
-          clearTimeout(timer); // Limpia el temporizador si el componente se desmonta antes
-        };
-      }
-    }, [deleteError]);
-
 
   if(isDeleted) {
     return null;
@@ -50,21 +36,18 @@ const CardPanel = ({ panel, index }) => {
   /**
    * Handles the click event on the delete button.
    * Deletes the panel if it contains no cards.
+   * Show message when the panel is not deleted.
    */
   const handleDeleteClick = () => {
-    if (panel.cards.length === 0){
-      deletePanel(panel.id).then((deleted) => {
-        if(deleted){
-          setIsDeleted(true);
-        } else {
-          setDeleteError("No se pudo eliminar el panel por algún motivo...");
-        }
-      }).catch((error) => {
-        setDeleteError("No se pudo eliminar el panel debido a un error en la solicitud.");
-      });
-    } else {
-      setDeleteError("No se pudo eliminar el panel por algún motivo...");
-    }
+    deletePanel(panel.id).then((response) => {
+      if(response.success){
+        setIsDeleted(true);
+      } else {
+        setAlertMessage(response.message);
+      }
+    }).catch((error) => {
+      setAlertMessage(error);
+    });
   };
 
   const menuComponent = (
@@ -85,31 +68,27 @@ const CardPanel = ({ panel, index }) => {
 
   return (
     <div>
-          <Snackbar open={!!deleteError} autoHideDuration={5000} onClose={() => setDeleteError(null)}>
-
-
-        {/* {deleteError && ( */}
+      <Snackbar open={!!alertMessage} autoHideDuration={5000} onClose={() => setAlertMessage(null)}>
         <Alert severity="error" key={"delete-error"}>
           <AlertTitle>Error</AlertTitle>
-          {deleteError}
+          {alertMessage}
         </Alert>
-      {/* )} */}
-          </Snackbar>
-    <div
-      onMouseEnter={()=> setShowMenu(true)}
-      onMouseLeave={()=> setShowMenu(false)}
-      style={{position: 'relative'}}
-      key={"title-panel"}
-    >
-        <BasePanel panel={panel} index={index} title={title}>
-                    {panel.cards.map((card, index) => (
-                        <Grid item xs={12} sm={6} md={11} key={card.consultation} >
-                        <CardTicket card={card} index={index} key={card.consultation}/>
-                        </Grid>
-                    ))}
-        </BasePanel>
-        {menuComponent}
-    </div>
+      </Snackbar>
+      <div
+        onMouseEnter={()=> setShowMenu(true)}
+        onMouseLeave={()=> setShowMenu(false)}
+        style={{position: 'relative'}}
+        key={"title-panel"}
+      >
+          <BasePanel panel={panel} index={index} title={title}>
+                      {panel.cards.map((card, index) => (
+                          <Grid item xs={12} sm={6} md={11} key={card.consultation} >
+                          <CardTicket card={card} index={index} key={card.consultation}/>
+                          </Grid>
+                      ))}
+          </BasePanel>
+          {menuComponent}
+      </div>
     </div>
   );
 };

--- a/com/frontend/app/src/containers/CardPanel.jsx
+++ b/com/frontend/app/src/containers/CardPanel.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import Grid from '@mui/material/Grid';
 import CardTicket from './CardTicket';
 import TitlePanel from '../components/TitlePanel';
@@ -18,11 +18,21 @@ import { deletePanel } from '../utils/panel';
 const CardPanel = ({ panel, index }) => {
   const [showMenu, setShowMenu] = useState(false);
   const title = TitlePanel({panel:panel, isEditable: true});
+  const [isDeleted, setIsDeleted] = useState(false);
+
+  useEffect(() => {
+  }, [isDeleted]);
+
+  if(isDeleted) {
+    return null;
+  }
 
   const handleDeleteClick = () => {
-    deletePanel(panel.id);
-    setShowMenu(false)
-    //TODO: actualizar vista
+    deletePanel(panel.id).then((deleted) => {
+      if(deleted){
+        setIsDeleted(true);
+      }
+    });
   };
 
   const menuComponent = (

--- a/com/frontend/app/src/containers/CardPanel.jsx
+++ b/com/frontend/app/src/containers/CardPanel.jsx
@@ -1,8 +1,11 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Grid from '@mui/material/Grid';
 import CardTicket from './CardTicket';
 import TitlePanel from '../components/TitlePanel';
 import BasePanel from '../components/BasePanel';
+import TicketMenu from '../components/TicketMenu';
+import { MenuItem } from '@mui/material';
+import { deletePanel } from '../utils/panel';
 
 
 /**
@@ -13,16 +16,47 @@ import BasePanel from '../components/BasePanel';
  * @returns {JSX.Element} - A React element representing the CardPanel.
  */
 const CardPanel = ({ panel, index }) => {
+  const [showMenu, setShowMenu] = useState(false);
   const title = TitlePanel({panel:panel, isEditable: true});
 
+  const handleDeleteClick = () => {
+    deletePanel(panel.id);
+    setShowMenu(false)
+    //TODO: actualizar vista
+  };
+
+  const menuComponent = (
+    <div
+      invisible={true}
+      style={{
+        position: 'absolute',
+        top: '0',
+        right: '0',
+      }}
+    >
+      <TicketMenu showMenu={showMenu} key={"menu"}>
+        <MenuItem onClick={handleDeleteClick}>Delete</MenuItem>
+      </TicketMenu>
+    </div>
+  );
+
+
   return (
-    <BasePanel panel={panel} index={index} title={title}>
-                {panel.cards.map((card, index) => (
-                    <Grid item xs={12} sm={6} md={11} key={card.consultation} >
-                    <CardTicket card={card} index={index} key={card.consultation}/>
-                    </Grid>
-                ))}
-    </BasePanel>
+    <div
+      onMouseEnter={()=> setShowMenu(true)}
+      onMouseLeave={()=> setShowMenu(false)}
+      style={{position: 'relative'}}
+      key={"title-panel"}
+    >
+        <BasePanel panel={panel} index={index} title={title}>
+                    {panel.cards.map((card, index) => (
+                        <Grid item xs={12} sm={6} md={11} key={card.consultation} >
+                        <CardTicket card={card} index={index} key={card.consultation}/>
+                        </Grid>
+                    ))}
+        </BasePanel>
+        {menuComponent}
+    </div>
   );
 };
 

--- a/com/frontend/app/src/containers/CardPanel.jsx
+++ b/com/frontend/app/src/containers/CardPanel.jsx
@@ -27,12 +27,18 @@ const CardPanel = ({ panel, index }) => {
     return null;
   }
 
+  /**
+   * Handles the click event on the delete button.
+   * Deletes the panel if it contains no cards.
+   */
   const handleDeleteClick = () => {
-    deletePanel(panel.id).then((deleted) => {
-      if(deleted){
-        setIsDeleted(true);
-      }
-    });
+    if (panel.cards.length === 0){
+      deletePanel(panel.id).then((deleted) => {
+        if(deleted){
+          setIsDeleted(true);
+        }
+      });
+    }
   };
 
   const menuComponent = (

--- a/com/frontend/app/src/containers/CardPanel.jsx
+++ b/com/frontend/app/src/containers/CardPanel.jsx
@@ -65,30 +65,32 @@ const CardPanel = ({ panel, index }) => {
     </div>
   );
 
+  const customAlert = (
+      <Snackbar open={!!alertMessage} autoHideDuration={5000} onClose={() => setAlertMessage(null)}>
+      <Alert severity="error" key={"delete-error"}>
+        <AlertTitle>Error</AlertTitle>
+        {alertMessage}
+      </Alert>
+    </Snackbar>
+  );
+
 
   return (
-    <div>
-      <Snackbar open={!!alertMessage} autoHideDuration={5000} onClose={() => setAlertMessage(null)}>
-        <Alert severity="error" key={"delete-error"}>
-          <AlertTitle>Error</AlertTitle>
-          {alertMessage}
-        </Alert>
-      </Snackbar>
-      <div
-        onMouseEnter={()=> setShowMenu(true)}
-        onMouseLeave={()=> setShowMenu(false)}
-        style={{position: 'relative'}}
-        key={"title-panel"}
-      >
-          <BasePanel panel={panel} index={index} title={title}>
-                      {panel.cards.map((card, index) => (
-                          <Grid item xs={12} sm={6} md={11} key={card.consultation} >
-                          <CardTicket card={card} index={index} key={card.consultation}/>
-                          </Grid>
-                      ))}
-          </BasePanel>
-          {menuComponent}
-      </div>
+    <div
+      onMouseEnter={()=> setShowMenu(true)}
+      onMouseLeave={()=> setShowMenu(false)}
+      style={{position: 'relative'}}
+      key={"title-panel"}
+    >
+        <BasePanel panel={panel} index={index} title={title}>
+                    {panel.cards.map((card, index) => (
+                        <Grid item xs={12} sm={6} md={11} key={card.consultation} >
+                        <CardTicket card={card} index={index} key={card.consultation}/>
+                        </Grid>
+                    ))}
+        </BasePanel>
+        {menuComponent}
+        {customAlert}
     </div>
   );
 };

--- a/com/frontend/app/src/containers/ConsultationTicket.jsx
+++ b/com/frontend/app/src/containers/ConsultationTicket.jsx
@@ -40,7 +40,7 @@ const ConsultationTicket = ({card, index, reduce_number_cards}) => {
 
     const cardContentProps = {
       "onMouseEnter": ()=> setShowMenu(true),
-      "onMouseLeave": ()=> setIsDeleted(false)
+      "onMouseLeave": ()=> setShowMenu(false)
     }
 
   return (

--- a/com/frontend/app/src/utils/panel.jsx
+++ b/com/frontend/app/src/utils/panel.jsx
@@ -85,11 +85,13 @@ export const updatPanelTitle = async (id, newTitle) => {
 
 
 /**
- * Delete a panel from the REST API.
+ * Deletes a panel by making a DELETE request to the REST API.
  *
- * @param {number} id - The ID of the panel to delete.
- * @returns {Promise<boolean>} - A promise that resolves to true if the panel is deleted successfully, or false otherwise.
- * @throws {Error} - Throws an error if there's an issue with the deletion process.
+ * @param {string|number} id - The ID of the panel to be deleted.
+ * @returns {Promise} A promise that resolves to an object with information about the deletion result.
+ *                    - success (boolean): true if the deletion was successful, false otherwise.
+ *                    - message (string): A message related to the deletion.
+ * @throws {Error} If an error occurs during the deletion request.
  */
 export const deletePanel = async(id) => {
     const url = process.env.REACT_APP_URL_BASE_API_REST_PATROCINIO
@@ -105,13 +107,14 @@ export const deletePanel = async(id) => {
             },
         });
 
+        const responseData = await response.json();
         if (!response.ok) {
             console.error(`Failed to DELETE Panel: ${response.statusText}`);
-            return false;
+            return {success: false, message: responseData.message};
         }
 
         console.info("Panel deleted successfully..")
-        return true
+        return {success: true, message: responseData.message};
 
     } catch (error) {
         console.error('Error deleting panel:', error.message);

--- a/com/frontend/app/src/utils/panel.jsx
+++ b/com/frontend/app/src/utils/panel.jsx
@@ -23,7 +23,7 @@ async function createPanel(titlePanel, boardID) {
 
         let status_response = true;
         if (!response.ok) {
-            console.error(`Error: ${response.statusText}`);
+            console.error(`Failed to POST Panel: ${response.statusText}`);
             status_response = false;
         }
 
@@ -79,6 +79,42 @@ export const updatPanelTitle = async (id, newTitle) => {
     } catch (error) {
         console.error(`Error while making the PATCH request for the Title field of Panel:`, error.message);
         console.debug(error);
+        throw error;
+    }
+};
+
+
+/**
+ * Delete a panel from the REST API.
+ *
+ * @param {number} id - The ID of the panel to delete.
+ * @returns {Promise<boolean>} - A promise that resolves to true if the panel is deleted successfully, or false otherwise.
+ * @throws {Error} - Throws an error if there's an issue with the deletion process.
+ */
+export const deletePanel = async(id) => {
+    const url = process.env.REACT_APP_URL_BASE_API_REST_PATROCINIO
+    + process.env.REACT_APP_PATH_PANELS
+    + String(id)
+    + "/";
+
+    try {
+        const response = await fetch(url, {
+            method: 'DELETE',
+            headers: {
+            'Content-Type': 'application/json',
+            },
+        });
+
+        if (!response.ok) {
+            console.error(`Failed to DELETE Panel: ${response.statusText}`);
+            return false;
+        }
+
+        console.info("Panel deleted successfully..")
+        return true
+
+    } catch (error) {
+        console.error('Error deleting panel:', error.message);
         throw error;
     }
 };


### PR DESCRIPTION
- Se agrega un menu en el panel que nos desplega la opcion de elimanr panel.
- Se actualiza el enpoint para eliminar un panel en el backend. Solo elimina un panel si no contiene cards.
- Se agrega un nuevo endpoint en el backend para forzar la eliminacion de un panel aunque este tenga cards: /force-destroy. (backend)
- Se agrega un Alert que se visualiza cuando ocurre un error al intentar eliminar un panel.
- Se agrega funcion en el frontend para interactuar con la API y eliminar el panel, finalizando en la renderización del componente panel.